### PR TITLE
Fix incorrect property name in `Datacenter` model class

### DIFF
--- a/src/main/java/me/tomsdevsn/hetznercloud/objects/general/Datacenter.java
+++ b/src/main/java/me/tomsdevsn/hetznercloud/objects/general/Datacenter.java
@@ -9,7 +9,7 @@ import java.util.List;
 public class Datacenter {
 
     private Long id;
-    private String command;
+    private String name;
     private String description;
     private Location location;
     @JsonProperty("server_types")


### PR DESCRIPTION
On first sight I couldn't find any actual (de)serialization code for this model class, so I assume it's automatically wired up and this little fix should be all that's required.