### PR TITLE
Fix erroneous type of `finished` property on `Action` model class

### DIFF
--- a/src/main/java/me/tomsdevsn/hetznercloud/objects/response/Action.java
+++ b/src/main/java/me/tomsdevsn/hetznercloud/objects/response/Action.java
@@ -16,7 +16,8 @@ public class Action {
     public Long progress;
     @JsonDeserialize(using = DateDeserializer.class)
     public Date started;
-    public boolean finished;
+    @JsonDeserialize(using = DateDeserializer.class)
+    public Date finished;
     public List<Resources> resources;
     private Error error;
 


### PR DESCRIPTION
This problem is quite severe as it blows up the response deserialization of any API response containing an `Action` that has already finished...